### PR TITLE
Fix: broken checkoutflow in MultiSafepay, support for deferred redirect

### DIFF
--- a/src/UCommerce.Transactions.Payments.MultiSafepay/MultiSafePayPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.MultiSafepay/MultiSafePayPaymentMethodService.cs
@@ -12,7 +12,7 @@ namespace UCommerce.Transactions.Payments.MultiSafepay
 	/// MultiSafepay Connect payment method service.
 	/// </summary>
 	/// <remarks>Setup to use the MtultiSafepay Connect option.</remarks>
-	public class MultiSafepayPaymentMethodService : ExternalPaymentMethodService
+	public class MultiSafepayPaymentMethodService : ExternalPaymentMethodService, IRequireRedirect
 	{
 		private readonly ILoggingService _loggingService;
 		public IOrderService OrderService { get; set; }
@@ -81,9 +81,9 @@ namespace UCommerce.Transactions.Payments.MultiSafepay
 
 			if (transactionIdXmlNode.InnerText != paymentRequest.Payment.ReferenceId)
 				throw new SecurityException("Transaction ID doesn't match internal reference id.");
-
-            HttpContext.Current.Items["UCommerceRedirectUrlForPayment"] = paymentUrlXmlNode.InnerText;
-
+			
+			paymentRequest.Payment["redirectUrl"] = paymentUrlXmlNode.InnerText;
+            
 			return paymentRequest.Payment;
 		}
 
@@ -240,6 +240,11 @@ namespace UCommerce.Transactions.Payments.MultiSafepay
 		protected override bool RefundPaymentInternal(Payment payment, out string status)
 		{
 			throw new NotSupportedException("Remote refund is not supported, use the backend office.");
+		}
+
+		public string GetRedirectUrl(Payment payment)
+		{
+			return payment["redirectUrl"];
 		}
 	}
 }


### PR DESCRIPTION
Framework for deferred redirect was broken in MultiSafepay, fixed it by implementing IRequiredRedirect, putting the redirectUrl in a Custom Payment Property, and using that in the GetRedirectUrl method from IRequiredRedirect.