### PR TITLE
chore: replace abstractpagebuilder method

### DIFF
--- a/src/UCommerce.Transactions.Payments.PayEx/PayExPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.PayEx/PayExPaymentMethodService.cs
@@ -93,7 +93,7 @@ namespace Ucommerce.Transactions.Payments.PayEx
 			const string creditcard = "CREDITCARD";
 			var clientLanguage = LocalizationContext.CurrentCultureCode;
 
-			string cancelUrl = AbstractPageBuilder.GetAbsoluteUrl(cancelUrlForPaymentMethod);
+			string cancelUrl = _absoluteUrlService.GetAbsoluteUrl(cancelUrlForPaymentMethod);
 
 			string value =	accountNumber +
 							purchaseOperation +


### PR DESCRIPTION
[CH9718]

- Changes made in GlobalCollectPaymentMethodService.cs and PayExPaymentMehodService.cs
- These changes are made because GetAbsoluteUrl and GetCallbackUrl methods have been removed from AbstractPagebuilder class.