### PR TITLE
Feature/11329 braintree enable 3ds

### DIFF
--- a/src/UCommerce.Transactions.Payments.Braintree/BraintreePageBuilder.cs
+++ b/src/UCommerce.Transactions.Payments.Braintree/BraintreePageBuilder.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Web;
 using Braintree;
-using Ucommerce.EntitiesV2;
 using Ucommerce.Extensions;
 using Ucommerce.Web;
 using Environment = Braintree.Environment;
@@ -48,52 +45,15 @@ namespace Ucommerce.Transactions.Payments.Braintree
 			string callbackUrl = paymentRequest.PaymentMethod.DynamicProperty<string>().CallbackUrl;
 			string paymentFormTemplate = paymentRequest.PaymentMethod.DynamicProperty<string>().PaymentFormTemplate;
 
-			var gateway = new BraintreeGateway
-							  {
-								  Configuration =
-									  new global::Braintree.Configuration(
-									  testMode ? Environment.SANDBOX : Environment.PRODUCTION,
-									  merchantId, publicKey, privateKey)
-							  };
-
 			AddPaymentForm(page, paymentFormTemplate);
+			
+			var environment = testMode ? Environment.SANDBOX : Environment.PRODUCTION;
+			var gateway = new BraintreeGateway(environment, merchantId, publicKey, privateKey);
+			var clientToken = gateway.ClientToken.Generate();
+			page.Replace(@"##CLIENT_TOKEN##", $@"{clientToken}");
 
-			page.Replace(@"##ACTIONURL##", string.Format(@"{0}", gateway.TransparentRedirect.Url));
-
-			OrderAddress billingAddress = paymentRequest.Payment.PurchaseOrder.BillingAddress;
-
-			//Braintree code will convert decimal to string using current thread culture, but reqiures invarinat format.
-			//Set culture temporarily in 'en-us'
-			var currentCulture = Thread.CurrentThread.CurrentCulture;
-			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-us");
-			string trData = gateway.Transaction.SaleTrData(
-				new TransactionRequest
-					{
-						Amount = Math.Round(paymentRequest.Payment.Amount, 2), // Braintree throws an error "Invalid Amount", if the amount has more than two digits.
-						OrderId = paymentRequest.Payment.ReferenceId,
-						PurchaseOrderNumber = string.IsNullOrEmpty(paymentRequest.Payment.PurchaseOrder.OrderNumber) ? "" : paymentRequest.Payment.PurchaseOrder.OrderNumber,
-						BillingAddress =
-							new AddressRequest
-								{
-									FirstName = billingAddress.FirstName,
-									LastName = billingAddress.LastName,
-									StreetAddress = billingAddress.Line1,
-									ExtendedAddress = billingAddress.Line2,
-									PostalCode = billingAddress.PostalCode,
-									CountryName = billingAddress.Country.Name,
-									Company = billingAddress.CompanyName
-								},
-					},
-				_callbackUrl.GetCallbackUrl(callbackUrl, paymentRequest.Payment));
-			Thread.CurrentThread.CurrentCulture = currentCulture;
-			page.Replace(@"##TRDATA##", string.Format(@"{0}", trData));
-
-			page.Replace(@"##EXPMONTH##", string.Format(@"{0}", CreateSelectOptions(new[] { "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12" })));
-
-			var years = new string[10];
-			for (int i = 0; i < 10; i++)
-				years[i] = (DateTime.Now.Year + i).ToString(CultureInfo.InvariantCulture);
-			page.Replace(@"##EXPYEAR##", string.Format(@"{0}", CreateSelectOptions(years)));
+			var callbackUrlWithPayment = _callbackUrl.GetCallbackUrl(callbackUrl, paymentRequest.Payment);
+			page.Replace(@"##CALLBACK_URL##", $@"{callbackUrlWithPayment}");
 
 			//Braintree will redirect back in case of errors and we will have to display them.
 			string errorMessages = HttpContext.Current.Request.QueryString["errorMessage"];
@@ -101,11 +61,11 @@ namespace Ucommerce.Transactions.Payments.Braintree
 			{
 				var errorMessageBuilder = new StringBuilder();
 				foreach (string errorMessage in errorMessages.Split(';'))
-					errorMessageBuilder.Append(string.Format("<li>{0}</li>", errorMessage));
-				page.Replace(@"##ERRORMESSAGES##", string.Format(@"<ul>{0}</ul>", errorMessageBuilder));
+					errorMessageBuilder.Append($"<li>{errorMessage}</li>");
+				page.Replace(@"##ERROR_MESSAGES##", $@"<ul>{errorMessageBuilder}</ul>");
 			}
 			else
-				page.Replace(@"##ERRORMESSAGES##", "");
+				page.Replace(@"##ERROR_MESSAGES##", "");
 		}
 
 		/// <summary>
@@ -131,7 +91,7 @@ namespace Ucommerce.Transactions.Payments.Braintree
 		{
 			var stringBuilder = new StringBuilder();
 			foreach (var value in values)
-				stringBuilder.Append(string.Format("<option value=\"{0}\" >{0}</option>", value));
+				stringBuilder.Append($"<option value=\"{value}\" >{value}</option>");
 			return stringBuilder.ToString();
 		}
 	}

--- a/src/UCommerce.Transactions.Payments.Braintree/BraintreePaymentForm.htm
+++ b/src/UCommerce.Transactions.Payments.Braintree/BraintreePaymentForm.htm
@@ -18,15 +18,19 @@
 <script type="text/javascript">
 	const form = document.getElementById('payment-form');
 	const serverErrorsHTML = '##ERROR_MESSAGES##';
+	const threeDSecureParameters = JSON.parse('##THREE_D_SECURE_PARAMETERS##');
 
 	braintree.dropin.create({
 		authorization: '##CLIENT_TOKEN##',
-		container: '#dropin-container'
+		container: '#dropin-container',
+		threeDSecure: true
 	}).then(dropinInstance => {
 		form.addEventListener('submit', event => {
 			event.preventDefault();
 
-			dropinInstance.requestPaymentMethod().then((payload) => {
+			dropinInstance.requestPaymentMethod({
+				threeDSecure: threeDSecureParameters
+			}).then((payload) => {
 				document.getElementById('nonce').value = payload.nonce;
 				form.submit();
 			}).catch(error => {

--- a/src/UCommerce.Transactions.Payments.Braintree/BraintreePaymentForm.htm
+++ b/src/UCommerce.Transactions.Payments.Braintree/BraintreePaymentForm.htm
@@ -1,55 +1,52 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-	<head>
-		<title>Braintree</title>
-	</head>
-	<body>
-		<form id="paymentForm" method="post" action="##ACTIONURL##" autocomplete="off">
-			<input type="hidden" name="tr_data" value="##TRDATA##"/>
-            ##ERRORMESSAGES##
-			<table>
-				<tr>
-					<td>
-						<label id="cardNumberLabel" for="transaction[credit_card][number]">Card number:</label>
-					</td>
-					<td>
-						<input type="text" id="paymentFormCardNumberInput" name="transaction[credit_card][number]"/>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<label id="expirationMonthLabel" for="transaction[credit_card][expiration_month]">Expiration month:</label>
-					</td>
-					<td>
-						<select id="paymentFormExpirationMonthSelect" name="transaction[credit_card][expiration_month]">##EXPMONTH##</select>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<label id="expirationYearLabel" for="transaction[credit_card][expiration_year]">Expiration year:</label>
-					</td>
-					<td>
-						<select id="paymentFormExpirationYearSelect" name="transaction[credit_card][expiration_year]">##EXPYEAR##</select>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<label id="cvvLabel" for="transaction[credit_card][cvv]">CVV:</label>
-					</td>
-					<td>
-						<input type="text" id="paymentFormCvvInput" name="transaction[credit_card][cvv]"/>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<label id="cardholderNameLabel" for="transaction[credit_card][cardholder_name]">Cardholder name:</label>
-					</td>
-					<td>
-						<input type="text" id="paymentFormCardholderNameInput" name="transaction[credit_card][cardholder_name]"/>
-					</td>
-				</tr>
-			</table>
-			<input type="submit" name="submitForm" value="Post it"/>
-		</form>
-	</body>
+<head>
+	<meta charset="utf-8">
+	<title>Braintree</title>
+	<script src="https://js.braintreegateway.com/web/dropin/1.25.0/js/dropin.min.js"></script>
+</head>
+
+<body>
+	<form id="payment-form" method="post" action='##CALLBACK_URL##'>
+		<div id="dropin-container"></div>
+		<input type="hidden" id="nonce" name="payment_method_nonce"/>
+		<input type="submit" value="Confirm" />
+	</form>
+	<div id="payment-errors" style="color: red">##ERROR_MESSAGES##</div>
+</body>
+
+<script type="text/javascript">
+	const form = document.getElementById('payment-form');
+	const serverErrorsHTML = '##ERROR_MESSAGES##';
+
+	braintree.dropin.create({
+		authorization: '##CLIENT_TOKEN##',
+		container: '#dropin-container'
+	}).then(dropinInstance => {
+		form.addEventListener('submit', event => {
+			event.preventDefault();
+
+			dropinInstance.requestPaymentMethod().then((payload) => {
+				document.getElementById('nonce').value = payload.nonce;
+				form.submit();
+			}).catch(error => {
+				showError(error);
+			});
+		});
+	}).catch(error => {
+		showError(error);
+	});
+
+	function showError(errorMsg) {
+		const paymentErrorsElement = document.getElementById('payment-errors');
+		paymentErrorsElement.innerHTML = serverErrorsHTML;
+
+		if (!paymentErrorsElement.firstChild)
+			paymentErrorsElement.innerHTML = '<ul></ul>';
+
+		const newErrorElement = document.createElement('li');
+		newErrorElement.textContent = errorMsg;
+		paymentErrorsElement.firstChild.appendChild(newErrorElement);
+	}
+</script>
 </html>

--- a/src/UCommerce.Transactions.Payments.Braintree/UCommerce.Transactions.Payments.Braintree.csproj
+++ b/src/UCommerce.Transactions.Payments.Braintree/UCommerce.Transactions.Payments.Braintree.csproj
@@ -30,11 +30,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Braintree-2.22.0, Version=2.22.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Braintree.2.22.0\lib\Braintree-2.22.0.dll</HintPath>
+    <Reference Include="Braintree, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31b586f34d3e96c7">
+      <HintPath>..\packages\Braintree.5.2.0\lib\net452\Braintree.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -99,6 +105,9 @@
   <ItemGroup>
     <None Include="Configuration\Braintree.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="BraintreePaymentForm.htm" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/UCommerce.Transactions.Payments.Braintree/UCommerce.Transactions.Payments.Braintree.csproj
+++ b/src/UCommerce.Transactions.Payments.Braintree/UCommerce.Transactions.Payments.Braintree.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/UCommerce.Transactions.Payments.Braintree/packages.config
+++ b/src/UCommerce.Transactions.Payments.Braintree/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Braintree" version="2.22.0" targetFramework="net45" />
+  <package id="Braintree" version="5.2.0" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net47" />
   <package id="uCommerce.Core" version="9.3.1.20275" targetFramework="net47" />
 </packages>

--- a/tools/Deploy.As.Apps.ps1
+++ b/tools/Deploy.As.Apps.ps1
@@ -10,25 +10,42 @@ Param(
 
 # Payment providers registered here will be moved by this Deploy script.
 Function Get-Registered-Payment-Providers {
-
-	$paymentProviders = @("Adyen","Authorizedotnet","Braintree","Dibs","EPay","EWay","GlobalCollect","Ideal","MultiSafepay","Netaxept","Ogone","Payer","PayEx","PayPal","Quickpay","SagePay","Schibsted","SecureTrading","WorldPay","Stripe");
-
+	$paymentProviders = @(
+	    "Adyen",
+	    "Authorizedotnet",
+	    "Braintree",
+	    "Dibs",
+	    "EPay",
+	    "EWay",
+	    "GlobalCollect",
+	    "Ideal",
+	    "MultiSafepay",
+	    "Netaxept",
+	    "Ogone",
+	    "Payer",
+	    "PayEx",
+	    "PayPal",
+	    "Quickpay",
+	    "SagePay",
+	    "Schibsted",
+	    "SecureTrading",
+	    "Stripe",
+	    "WorldPay"
+    );
 	return $paymentProviders;
 }
-
 
 function Get-ScriptDirectory { 
     Split-Path -parent $PSCommandPath 
 }
 
 function Run-It () {
-	$solution_file = "Ucommerce.Transactions.Payments.sln";
-
 	$scriptPath = Get-ScriptDirectory;
-
 	$src = Resolve-Path "$scriptPath\..\src";
 
 	foreach($element in Get-Registered-Payment-Providers){
+	    $projectPath = "$src/Ucommerce.Transactions.Payments.$element";
+	    
 		Write-Host "Deploying > $element"
 
 		if(Test-Path -Path $TargetPath\$element)
@@ -37,25 +54,26 @@ function Run-It () {
 		}
 
 		New-Item -Type Directory "$TargetPath\$element\bin" -Force
-		Copy-Item "$src/Ucommerce.Transactions.Payments.$element\bin\$Configuration\Ucommerce.Transactions.Payments.$element.dll" -Destination "$TargetPath\$element\bin" -Force
-		Copy-Item "$src/Ucommerce.Transactions.Payments.$element\Configuration" -Destination "$TargetPath\$element\Configuration" -Force -Recurse
+		Copy-Item "$projectPath\bin\$Configuration\Ucommerce.Transactions.Payments.$element.dll" -Destination "$TargetPath\$element\bin" -Force
+		Copy-Item "$projectPath\Configuration" -Destination "$TargetPath\$element\Configuration" -Force -Recurse
 
 		# DLL Dependency necessary for PayPal
 		if($element -eq "PayPal"){
-			Copy-Item "$src/Ucommerce.Transactions.Payments.$element\bin\$Configuration\paypal_base.dll" -Destination "$TargetPath\$element\bin" -Force
+			Copy-Item "$projectPath\bin\$Configuration\paypal_base.dll" -Destination "$TargetPath\$element\bin" -Force
 		}
 
 		# DLL Dependency necessary for Braintree
 		if($element -eq "Braintree"){
-			Copy-Item "$src/Ucommerce.Transactions.Payments.$element\bin\$Configuration\Braintree-2.22.0.dll" -Destination "$TargetPath\$element\bin" -Force
-			Copy-Item "$src/Ucommerce.Transactions.Payments.$element\BraintreePaymentForm.htm" -Destination "$TargetPath\$element" -Force
+			Copy-Item "$projectPath\bin\$Configuration\Braintree.dll" -Destination "$TargetPath\$element\bin" -Force
+			Copy-Item "$projectPath\bin\$Configuration\Newtonsoft.Json.dll" -Destination "$TargetPath\$element\bin" -Force
+			Copy-Item "$projectPath\BraintreePaymentForm.htm" -Destination "$TargetPath\$element" -Force
 		}
 
 		# DLL Dependency necessary for Stripe
 		if($element -eq "Stripe"){
-			Copy-Item "$src/Ucommerce.Transactions.Payments.$element\bin\$Configuration\Stripe.net.dll" -Destination "$TargetPath\$element\bin" -Force
-			Copy-Item "$src/Ucommerce.Transactions.Payments.$element\bin\$Configuration\Microsoft.Bcl.AsyncInterfaces.dll" -Destination "$TargetPath\$element\bin" -Force
-			Copy-Item "$src/Ucommerce.Transactions.Payments.$element\StripePaymentForm.htm" -Destination "$TargetPath\$element" -Force
+			Copy-Item "$projectPath\bin\$Configuration\Stripe.net.dll" -Destination "$TargetPath\$element\bin" -Force
+			Copy-Item "$projectPath\bin\$Configuration\Microsoft.Bcl.AsyncInterfaces.dll" -Destination "$TargetPath\$element\bin" -Force
+			Copy-Item "$projectPath\StripePaymentForm.htm" -Destination "$TargetPath\$element" -Force
 		}
 
 		Write-Host "Deployed > $element"
@@ -63,7 +81,6 @@ function Run-It () {
 	}
 
 	Write-Host "Finished deploying payment provider apps to $TargetPath";
-	
 }
 
 Run-It


### PR DESCRIPTION
### Solution

Based on:
- https://github.com/braintree/braintree_aspnet_example/tree/master/BraintreeASPExample
- https://developers.braintreepayments.com/guides/3d-secure/client-side/javascript/v3
- https://developers.braintreepayments.com/guides/3d-secure/server-side/dotnet
- https://developers.braintreepayments.com/start/hello-server/dotnet#create-a-transaction
- [Braintree CodePen example of the Drop-in UI with 3D Secure 2.0 implemented](https://codepen.io/braintree/pen/KjWqGx)

**Note:** For 3DS I passed as little data as possible, the data passed is up to the customers.

### Pre-requisites for testing:
- install `Ucommerce 9.3.1.20275` on `Umbraco 8`
- install `Avenue_Clothing_Umbraco8_7.3.1.20275`
- setup `Braintree` by following
https://docs.ucommerce.net/ucommerce/v9.3/payment-providers/general-setup-of-payment-methods.html
https://docs.ucommerce.net/ucommerce/v9.3/payment-providers/setup-braintree-as-a-payment-method.html
(docs articles are slighly outdated)
- login into https://sandbox.braintreegateway.com/login

### Testing
1. Build the solution
2. Copy following dlls into `Website\Umbraco\ucommerce\Apps\Braintree\bin`
    - `Braintree.dll`
    - `Newtonsoft.Json.dll`
    - `Ucommerce.Transactions.Payments.Braintree.dll`
3. Copy the following file into `Website\Umbraco\ucommerce\Apps\Braintree`
    - `BraintreePaymentForm.htm`
4. Run `iisreset`, request the site, go through checkout flow in Avenue
5. Delete your Braintree app and run the deployment script e.g.
```ps1
.\Deploy.As.Apps.ps1 -TargetPath "c:\inetpub\u8\website\umbraco\ucommerce\apps" -Configuration Debug
```
6.  Run `iisreset`, request the site, go through checkout flow in Avenue
Try to break payment, inspiration for testing can be found here:
- https://developers.braintreepayments.com/reference/general/testing/dotnet
- https://developers.braintreepayments.com/guides/credit-cards/testing-go-live/dotnet

Tests I performed:
|	Tested values	|	Expected result	|	Result	|
|	---	|	---	|	---	|
|	Amount <br> between 2000.00 - 2999.99	|	From docs: <br>Processor Declined with a processor response equal to the amount 	|	As expected	|
|	Amount <br> 5001.00	|	From docs: <br>Gateway Rejected with a reason of Application Incomplete	|	Unexpected, went through	|
|	Amount <br>240 (price 200, VAT 20%) <br>Valid card number <br>Accept 3DS	|	New order in Ucommerce back-office <br>Transaction with `Authorized` state in Braintree	|	As expected	|
|	Amount <br>240 (price 200, VAT 20%) <br>Valid card number <br>Decline 3DS	|	Redirect to `PaymentRequest.axd` <br>1 server error displayed	|	As expected	|
|	Use query string parameter <br>?errorMessage=err1;err2;err3	|	3 server errors displayed	|	As expected	|
|	Submit form multiple times without filling the fields	|	1 client error appended just once	|	As expected	|
|	Use invalid card number <br>4000111111111115	|	From docs: <br>processor declined	|	Unexpected, went through	|

---
### 3DS observations
When creating `threeDSecureParameters` object, Braintree docs mentions something I couldn't reproduce:
```csharp
givenName: 'Jill', // ASCII-printable characters required, else will throw a validation error
surname: 'Doe', // ASCII-printable characters required, else will throw a validation error
```

---
### Acquire, Cancel, and Refund in Ucommerce

#### Testing Acquire + Refund actions:
1. Checkout new order through Avenue
2. Find your order under Ucommerce back-office => `Settings\Orders\New Order`
3. Open order, see `Payments` tab
    - use `Transaction Id` to identify transaction in Braintree
    - verify that `Payment Status` is `Authorized` both un Braintree and Ucommerce
4. See `Overview` tab
=> `Change status` to `Completed`
=> the status in Braintree will be `Submitted for settlement` or `Settled` + the amount will be positive number
5. Find your order under Ucommerce back-office => `Settings\Orders\Completed order`
=> `Change status` to `Cancelled`
=> the status in Braintree will be `Submitted for settlement` or `Settled` + the amount will be negative number

#### Testing Cancel action:
1. Checkout new order through Avenue
2. Find your order under Ucommerce back-office => `Settings\Orders\New Order`
3. `Change status` to `Cancelled` => the status in Braintree will now be `Voided`

## Note: don't forget to test in production.
https://developers.braintreepayments.com/guides/credit-cards/testing-go-live/dotnet#test-transactions-in-production