### PR TITLE
Update build to NUKE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ _ReSharper*
 src/packages/*
 src/.idea/*
 src/.vs/*
+
+.nuke/temp/
+artifacts/

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Build Schema",
+  "$ref": "#/definitions/build",
+  "definitions": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "DeployDirectory": {
+          "type": "string"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "type": "string",
+          "description": "Host for execution. Default is 'automatic'",
+          "enum": [
+            "AppVeyor",
+            "AzurePipelines",
+            "Bamboo",
+            "Bitrise",
+            "GitHubActions",
+            "GitLab",
+            "Jenkins",
+            "Rider",
+            "SpaceAutomation",
+            "TeamCity",
+            "Terminal",
+            "TravisCI",
+            "VisualStudio",
+            "VSCode"
+          ]
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "PatchAssemblyInfo": {
+          "type": "boolean",
+          "description": "Patch all assemblyinfo.cs files in the solution before compile"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Clean",
+              "CleanupPatchAssemblyInfo",
+              "Compile",
+              "DeployToLocal",
+              "GatherFiles",
+              "Package",
+              "PatchAssemblyInfo",
+              "Restore",
+              "UpdateUcommerceCore"
+            ]
+          }
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Clean",
+              "CleanupPatchAssemblyInfo",
+              "Compile",
+              "DeployToLocal",
+              "GatherFiles",
+              "Package",
+              "PatchAssemblyInfo",
+              "Restore",
+              "UpdateUcommerceCore"
+            ]
+          }
+        },
+        "UcommerceNugetSource": {
+          "type": "string",
+          "description": "The directory where the Ucommerce Core Nuget package can be found"
+        },
+        "Verbosity": {
+          "type": "string",
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Quiet",
+            "Verbose"
+          ]
+        },
+        "Version": {
+          "type": "string",
+          "description": "The version in semver format"
+        }
+      }
+    }
+  }
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "src/UCommerce.Transactions.Payments.sln"
+}

--- a/README.md
+++ b/README.md
@@ -16,18 +16,16 @@ Furthermore, the integrations being open-source allows for community pull-reques
 
 ### How do I deploy my custom fix as an app? ###
 
-Simply make your changes to the source code, then run the "Deploy.As.Apps.ps1" The powershell script will override what's already in the apps folder, so it goes without saying you need to make sure you can restore to a state before you started making modifications should everything become a mess.
-
-Before running the script make sure you have compiled the solution with either Debug or Release mode based on how you wish to deploy your changes. Otherwise the powershell script will fail as it tries to look for assemblies that does not exist.
+Simply make your changes to the source code, then run the "build.ps1" with the "DeployToLocal" target (See example below). The build script will overwrite what's already in the apps folder, so it goes without saying you need to make sure you can restore to a state before you started making modifications should everything become a mess.
 
 example usage
 ```
-.\Deploy.As.Apps.ps1 -TargetPath "c:\inetpub\u8\website\umbraco\ucommerce\apps" -Configuration Debug
+.\build.ps1 DeployToLocal --DeployDirectory "c:\inetpub\u8\website\umbraco\ucommerce\apps" --Configuration Debug
 ```
 
 ### I only need a few of the providers ###
 
-If you don't want to copy all the providers but only selected ones, you can either modify "$paymentProviders" array in the "Deploy.As.Apps.ps1" script and remove the ones you'd like to omit, or you can deploy all providers to a temporary location, and only copy the relevant ones into your website.
+If you don't want to copy all the providers but only selected ones, you can deploy all providers to a temporary location, and only copy the relevant ones into your website.
 
 ### Troubleshooting ###
 
@@ -36,5 +34,3 @@ A: In order to have Ucommerce load your application, you need to perform an appl
 
 Q: If I can't override the existing app, won't my DLL clash with the existing one?  
 A: You can disable the out of the box app (or any other apps) by adding a '.disabled' extension to the app folder's name. This will prevent any such issues.
-
-

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,7 @@
+:; set -eo pipefail
+:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+:; ${SCRIPT_DIR}/build.sh "$@"
+:; exit $?
+
+@ECHO OFF
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$BuildArguments
+)
+
+Write-Output "PowerShell $($PSVersionTable.PSEdition) version $($PSVersionTable.PSVersion)"
+
+Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { Write-Error $_ -ErrorAction Continue; exit 1 }
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+$BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
+$TempDirectory = "$PSScriptRoot\\.nuke\temp"
+
+$DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
+$DotNetChannel = "Current"
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function ExecSafe([scriptblock] $cmd) {
+    & $cmd
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
+     $(dotnet --version) -and $LASTEXITCODE -eq 0) {
+    $env:DOTNET_EXE = (Get-Command "dotnet").Path
+}
+else {
+    # Download install script
+    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
+    New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
+
+    # If global.json exists, load expected version
+    if (Test-Path $DotNetGlobalFile) {
+        $DotNetGlobal = $(Get-Content $DotNetGlobalFile | Out-String | ConvertFrom-Json)
+        if ($DotNetGlobal.PSObject.Properties["sdk"] -and $DotNetGlobal.sdk.PSObject.Properties["version"]) {
+            $DotNetVersion = $DotNetGlobal.sdk.version
+        }
+    }
+
+    # Install by channel or version
+    $DotNetDirectory = "$TempDirectory\dotnet-win"
+    if (!(Test-Path variable:DotNetVersion)) {
+        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
+    } else {
+        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
+    }
+    $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+}
+
+Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+
+ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+bash --version 2>&1 | head -n 1
+
+set -eo pipefail
+SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
+
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
+DOTNET_CHANNEL="Current"
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function FirstJsonValue {
+    perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
+    export DOTNET_EXE="$(command -v dotnet)"
+else
+    # Download install script
+    DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
+    mkdir -p "$TEMP_DIRECTORY"
+    curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+    chmod +x "$DOTNET_INSTALL_FILE"
+
+    # If global.json exists, load expected version
+    if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
+        DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
+        if [[ "$DOTNET_VERSION" == ""  ]]; then
+            unset DOTNET_VERSION
+        fi
+    fi
+
+    # Install by channel or version
+    DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
+    if [[ -z ${DOTNET_VERSION+x} ]]; then
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
+    else
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
+    fi
+    export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+fi
+
+echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/.editorconfig
+++ b/build/.editorconfig
@@ -1,0 +1,11 @@
+[*.cs]
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+dotnet_style_require_accessibility_modifiers = never:warning
+
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning

--- a/build/Build.PatchAssemblyInfo.cs
+++ b/build/Build.PatchAssemblyInfo.cs
@@ -1,0 +1,50 @@
+using System;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.Tools.Git;
+using Nuke.Common.Utilities;
+
+// These targets take care of patching the assemblyinfo.cs files, and cleaning up again, in the project
+partial class Build
+{
+    [Parameter("Patch all assemblyinfo.cs files in the solution before compile", Name = "PatchAssemblyInfo")]
+    bool ShouldPatchAssemblyInfo;
+
+    [Parameter("The version in semver format")] 
+    string Version = "0.0.0";
+    
+    string BuildNumber => $"{DateTime.Today:yy}{DateTime.Today.DayOfYear:000}";
+
+    string FullVersion => ShouldPatchAssemblyInfo ? $"{Version}.{BuildNumber}": Version;
+    
+    Target PatchAssemblyInfo => _ => _
+         .OnlyWhenStatic(() => ShouldPatchAssemblyInfo)
+         .DependentFor(Compile)
+         .Unlisted()
+         .Executes(() =>
+         {
+             var commitSha = GitTasks.GitCurrentCommit();
+             var assemblyInfoFiles = SourceDirectory.GlobFiles("**/AssemblyInfo.cs");
+             foreach (var assemblyInfoFile in assemblyInfoFiles)
+             {
+                 var contents = TextTasks.ReadAllText(assemblyInfoFile);
+
+                 var newContents = contents
+                     .ReplaceRegex("AssemblyVersion\\(.*\\)", _ => $"AssemblyVersion(\"{FullVersion}\")")
+                     .ReplaceRegex("AssemblyFileVersion\\(.*\\)", _ => $"AssemblyFileVersion(\"{FullVersion}\")")
+                     .ReplaceRegex("AssemblyInformationalVersion\\(.*\\)", _ => $"AssemblyInformationalVersion(\"{FullVersion} {commitSha}\")");
+                TextTasks.WriteAllText(assemblyInfoFile, newContents);                 
+             }
+         });
+
+    
+    // ReSharper disable once UnusedMember.Local
+    Target CleanupPatchAssemblyInfo => _ => _
+        .TriggeredBy(PatchAssemblyInfo)
+        .After(Compile)
+        .Unlisted()
+        .Executes(() =>
+        {
+            GitTasks.Git("checkout -- \"**\\AssemblyInfo.cs\"", SourceDirectory);
+        });
+}

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Helpers;
+using Nuke.Common;
+using Nuke.Common.Execution;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tools.MSBuild;
+using Nuke.Common.Tools.NuGet;
+using Nuke.Common.Utilities.Collections;
+using static Nuke.Common.IO.FileSystemTasks;
+using static Nuke.Common.Tools.MSBuild.MSBuildTasks;
+
+[CheckBuildProjectConfigurations]
+partial class Build : NukeBuild
+{
+    /// Support plugins are available for:
+    ///   - JetBrains ReSharper        https://nuke.build/resharper
+    ///   - JetBrains Rider            https://nuke.build/rider
+    ///   - Microsoft VisualStudio     https://nuke.build/visualstudio
+    ///   - Microsoft VSCode           https://nuke.build/vscode
+
+    public static int Main () => Execute<Build>(x => x.Compile);
+
+    [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
+    readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
+
+    [Solution] readonly Solution Solution;
+
+    AbsolutePath SourceDirectory => RootDirectory / "src";
+    AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
+
+    [Parameter("The directory where the Ucommerce Core Nuget package can be found")]
+    AbsolutePath UcommerceNugetSource
+    {
+        get => UcommerceNugetSourceField ?? ArtifactsDirectory;
+        set => UcommerceNugetSourceField = value;
+    }
+    AbsolutePath UcommerceNugetSourceField;
+
+    // ReSharper disable once UnusedMember.Local
+    Target Clean => _ => _
+        .Description("Cleans up bin and obj folders as well the artifacts directory.")
+        .Before(Restore)
+        .Executes(() =>
+        {
+            SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(DeleteDirectory);
+            EnsureCleanDirectory(ArtifactsDirectory);
+        });
+
+    Target Restore => _ => _
+        .Description("Restores nuget dependencies for the solution")
+        .Executes(() =>
+        {
+            NuGetTasks.NuGetRestore(settings => settings.SetTargetPath(Solution));
+        });
+
+    // ReSharper disable once UnusedMember.Local
+    Target UpdateUcommerceCore => _ => _
+        .Description("Updates the Ucommerce.Core dependency to one in a local folder\n\n" +
+                     "    The parameter `UcommerceNugetSource` defines the folder\n" +
+                     "    Default for `UcommerceNugetSource` is the artifacts directory.")
+        .After(Restore)
+        .Before(Compile)
+        .Executes(() =>
+        {
+            NuGetTasks.NuGet($"update {Solution.Path} -Id Ucommerce.Core -source {UcommerceNugetSource}");
+        });
+    
+    Target Compile => _ => _
+        .Description("Compiles the solution")
+        .DependsOn(Restore)
+        .Executes(() =>
+        {
+            MSBuild(s => s
+                .SetTargetPath(Solution)
+                .SetTargets("Rebuild")
+                .SetConfiguration(Configuration)
+                .SetMaxCpuCount(Environment.ProcessorCount)
+                .SetNodeReuse(IsLocalBuild));
+        });
+
+    AbsolutePath TempWorkDir => TemporaryDirectory / "dist";
+    Target GatherFiles => _ => _
+        .Description("Gathers payment providers to a local folder for use by package and deploy targets")
+        .DependsOn(Compile)
+        .Unlisted()
+        .Executes(() =>
+        {
+            EnsureCleanDirectory(TempWorkDir);
+            
+            // Some projects have extra files that need to be copied to output apart from the project dll and the configs. 
+            var projectExtraFilesHook = new Dictionary<string, Action<AbsolutePath, Configuration>>()
+            {
+                {"PayPal", (outputDirectory, configuration) =>
+                {
+                    var project = Solution.GetProject("Ucommerce.Transactions.Payments.PayPal");
+                    CopyFileToDirectory(
+                        project.GetOutputDir(configuration) / "paypal_base.dll", outputDirectory / "bin");
+                }},
+                {"Braintree", (outputDirectory, configuration) =>
+                {
+                    var project = Solution.GetProject("Ucommerce.Transactions.Payments.Braintree");
+                    CopyFileToDirectory(
+                        project.GetOutputDir(configuration) / "Braintree.dll", outputDirectory / "bin");
+                    CopyFileToDirectory(
+                        project.GetOutputDir(configuration) / "Newtonsoft.Json.dll", outputDirectory / "bin");
+                    CopyFileToDirectory(
+                        project.Directory / "BraintreePaymentForm.htm", outputDirectory);
+                }},
+                {"Stripe", (outputDirectory, configuration) =>
+                {
+                    var project = Solution.GetProject("Ucommerce.Transactions.Payments.Stripe");
+                    CopyFileToDirectory(
+                        project.GetOutputDir(configuration) / "Stripe.net.dll", outputDirectory / "bin");
+                    CopyFileToDirectory(
+                        project.GetOutputDir(configuration) / "Microsoft.Bcl.AsyncInterfaces.dll", outputDirectory / "bin");
+                    CopyFileToDirectory(
+                        project.Directory / "StripePaymentForm.htm", outputDirectory);
+                }}
+            };
+            
+            Solution
+                .GetProjects("Ucommerce.Transactions.Payments.*")
+                .Where(project => project.Name != "Ucommerce.Transactions.Payments.Test")
+                .ForEach(project =>
+                {
+                    var outputDir = project.GetOutputDir(Configuration);
+                    var providerName = project.Name.Split(".").Last();
+                    CopyFileToDirectory(outputDir / $"{project.Name}.dll", TempWorkDir / providerName / "bin");
+                    CopyDirectoryRecursively(project.Directory / "Configuration", TempWorkDir / providerName / "Configuration");
+                    if (projectExtraFilesHook.ContainsKey(providerName))
+                    {
+                        projectExtraFilesHook[providerName].Invoke(TempWorkDir / providerName, Configuration);
+                    }
+                });
+        });
+
+    // ReSharper disable once UnusedMember.Local
+    Target Package => _ => _
+        .Description("Packages the payment providers to the artifacts folder as paymentProviders.zip")
+        .DependsOn(GatherFiles)
+        .Executes(() =>
+        {
+            DeleteFile(ArtifactsDirectory / "paymentProviders.zip");
+            CompressionTasks.CompressZip(TempWorkDir, ArtifactsDirectory / "paymentProviders.zip");
+        });
+
+    [Parameter] AbsolutePath DeployDirectory;
+    
+    // ReSharper disable once UnusedMember.Local
+    Target DeployToLocal => _ => _
+        .Description("Deploys to a local folder like a website")
+        .DependsOn(GatherFiles)
+        .Requires(() => DeployDirectory)
+        .Executes(() =>
+        {
+            TempWorkDir.GlobDirectories("*").ForEach(path =>
+            {
+                var relativePath = TempWorkDir.GetRelativePathTo(path);
+                EnsureCleanDirectory(DeployDirectory / relativePath);
+                CopyDirectoryRecursively(path, DeployDirectory / relativePath, DirectoryExistsPolicy.Merge);
+            });
+        });
+}

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+    public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+    public static implicit operator string(Configuration configuration)
+    {
+        return configuration.Value;
+    }
+}

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- This file prevents unintended imports of unrelated MSBuild files -->
+  <!-- Uncomment to include parent Directory.Build.props file -->
+  <!--<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />-->
+
+</Project>

--- a/build/Directory.Build.targets
+++ b/build/Directory.Build.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- This file prevents unintended imports of unrelated MSBuild files -->
+  <!-- Uncomment to include parent Directory.Build.targets file -->
+  <!--<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />-->
+
+</Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace></RootNamespace>
+    <NoWarn>CS0649;CS0169</NoWarn>
+    <NukeRootDirectory>..</NukeRootDirectory>
+    <NukeScriptDirectory>..\tools</NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="NuGet.CommandLine" Version="[5.10.0]" />
+  </ItemGroup>
+
+</Project>

--- a/build/_build.csproj.DotSettings
+++ b/build/_build.csproj.DotSettings
@@ -1,0 +1,27 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=HeapView_002EDelegateAllocation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VariableHidesOuterVariable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBeMadeStatic_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/METHOD_OR_OPERATOR_BODY/@EntryValue">ExpressionBody</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">0</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_ATTRIBUTE_LENGTH_FOR_SAME_LINE/@EntryValue">120</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">IF_OWNER_IS_SINGLE_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">WRAP_IF_LONG</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/build/helpers/ProjectExtensions.cs
+++ b/build/helpers/ProjectExtensions.cs
@@ -1,0 +1,18 @@
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+
+namespace Helpers
+{
+    public static class ProjectExtensions
+    {
+        public static AbsolutePath GetOutputDir(this Project project, Configuration configuration)
+        {
+            return project.Directory / "bin" / configuration;
+        }
+        
+        public static void CopyProjectBinDir(this Project project, AbsolutePath targetDir, Configuration configuration)
+        {
+            FileSystemTasks.CopyDirectoryRecursively(project.GetOutputDir(configuration), targetDir);
+        }
+    }
+}

--- a/src/UCommerce.Transactions.Payments.sln
+++ b/src/UCommerce.Transactions.Payments.sln
@@ -52,12 +52,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ucommerce.Transactions.Paym
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ucommerce.Transactions.Payments.Stripe", "UCommerce.Transactions.Payments.Stripe\Ucommerce.Transactions.Payments.Stripe.csproj", "{9C11E828-50E0-45CC-8547-2A84BE424E1B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{B21207DA-C18C-4182-8EB4-4A2699A4A657}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B21207DA-C18C-4182-8EB4-4A2699A4A657}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B21207DA-C18C-4182-8EB4-4A2699A4A657}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33E2A3F7-D5F2-4F87-BE95-13BB3941FBBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{33E2A3F7-D5F2-4F87-BE95-13BB3941FBBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33E2A3F7-D5F2-4F87-BE95-13BB3941FBBF}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Moved the build scripts to NUKE to be more consistent with the Ucommerce
project itself. But also because we have an actually working version of
updating the AssemblyInfo files in NUKE.

To package the payment providers to a zip file just run the `Package`
target which will create a paymentProviders.zip file in the `artifacts/`
directory.

In our pipelines for Ucommerce it is very useful to be able to update
the nuget package for Ucommerce.Core to the latest one built there.
The `UpdateUcommerceCore` target makes this possible. It just needs to
know the directory where the `Ucommerce.Core.*.nupkg` file can be found.

The features of the scripts should be there still in the new build
system. Local deployment is still around as a new target named
`DeployToLocal`

Note: Later when everything is confirmed to work in the Ucommerce
pipeline and the old scripts have been removed from there, we can remove
the old powershell build scripts.

[ch-11660]