### PR TITLE
Install prerelease packages in nuke

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -65,7 +65,7 @@ partial class Build : NukeBuild
         .Before(Compile)
         .Executes(() =>
         {
-            NuGetTasks.NuGet($"update {Solution.Path} -Id Ucommerce.Core -source {UcommerceNugetSource}");
+            NuGetTasks.NuGet($"update {Solution.Path} -Id Ucommerce.Core -source {UcommerceNugetSource} -Prerelease");
         });
     
     Target Compile => _ => _


### PR DESCRIPTION
When running nuget update it should also update to prerelease version so
testing can be done on feature branches and other branches that create
prerelease packages.