### PR TITLE
Set missing `TransactionId`

### DIFF
--- a/src/UCommerce.Transactions.Payments.Adyen/AdyenPageBuilder.cs
+++ b/src/UCommerce.Transactions.Payments.Adyen/AdyenPageBuilder.cs
@@ -138,19 +138,24 @@ namespace Ucommerce.Transactions.Payments.Adyen
 			dict.Add("skinCode", paymentRequest.PaymentMethod.DynamicProperty<string>().SkinCode);
 			dict.Add("merchantAccount", paymentRequest.PaymentMethod.DynamicProperty<string>().MerchantAccount);
 			dict.Add("shopperLocale", LocalizationContext.CurrentCultureCode.Replace('-', '_'));
+
 			// orderData (optional)
 			dict.Add("sessionValidity", BuildFutureTimestamp(0, 0, paymentRequest.PaymentMethod.DynamicProperty<int>().SessionValidityPlusMinutes));
 			dict.Add("merchantReturnData", paymentRequest.Payment.ReferenceId);
+
 			if (!string.IsNullOrEmpty(paymentRequest.PurchaseOrder.BillingAddress.Country.TwoLetterISORegionName))
 				dict.Add("countryCode", paymentRequest.PurchaseOrder.BillingAddress.Country.TwoLetterISORegionName);
+
 			if (!string.IsNullOrEmpty(paymentRequest.PurchaseOrder.BillingAddress.EmailAddress))
 			{
 				dict.Add("shopperEmail", paymentRequest.PurchaseOrder.BillingAddress.EmailAddress);
 				dict.Add("shopperReference", paymentRequest.Payment.ReferenceId);
 			}
+
 			dict.Add("allowedMethods", paymentRequest.PaymentMethod.DynamicProperty<string>().AllowedMethods);
 			dict.Add("blockedMethods", paymentRequest.PaymentMethod.DynamicProperty<string>().BlockedMethods);
 			dict.Add("offset", paymentRequest.PaymentMethod.DynamicProperty<string>().Offset.ToString(CultureInfo.InvariantCulture)); // Per user value?
+
 			// shopperStatement (optional) // Per user value?
 			if (paymentRequest.PaymentMethod.DynamicProperty<bool>().OfferEmail)
 				dict.Add("offerEmail", "prompt");
@@ -181,7 +186,6 @@ namespace Ucommerce.Transactions.Payments.Adyen
 				var calculator = new HmacCalculator(HttpUtility.UrlDecode(paymentMethod.DynamicProperty<string>().HmacSharedSecret));
 				signature = calculator.Execute(signingString);
 			}
-
 
 			return signature;
 		}
@@ -217,7 +221,8 @@ namespace Ucommerce.Transactions.Payments.Adyen
 				.AddDays(daysIntoTheFuture)
 				.AddHours(hoursIntoTheFuture)
 				.AddMinutes(minutesIntoTheFuture)
-				.ToUniversalTime().ToString("s", DateTimeFormatInfo.InvariantInfo) + "Z";
+				.ToUniversalTime()
+				.ToString("s", DateTimeFormatInfo.InvariantInfo) + "Z";
 		}
 	}
 }

--- a/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
@@ -509,6 +509,7 @@ namespace Ucommerce.Transactions.Payments.Adyen
 		protected void ProcessPaymentNotificationMessage(Payment payment, Dictionary<string, string> dict)
 		{
 			var data = RetrieveNotificationMessageData(dict);
+			payment.TransactionId = data.PspReference;
 			payment[LatestPspReference] = data.PspReference;
 
             Guard.Against.MessageNotAuthenticated(ResultValidator.NotificationMessageIsAuthenticated(payment.PaymentMethod));

--- a/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
@@ -204,6 +204,7 @@ namespace Ucommerce.Transactions.Payments.Adyen
 
 			SetupWebServiceClients(payment.PaymentMethod);
 			SetupWebServiceCredentials(payment.PaymentMethod);
+
 			var result = PaymentClient.authorise(
 				new Adyen.Test.ModificationSoapService.PaymentRequest
 				{
@@ -399,6 +400,7 @@ namespace Ucommerce.Transactions.Payments.Adyen
 			var data = RetrieveAuthenticationResultMessageData(dict);
 			payment.TransactionId = data.PspReference;
 			payment[LatestPspReference] = data.PspReference;
+			payment.Save();
 
 			var authenticatedOrPending = false;
 			switch (data.AuthorizationResult)
@@ -509,7 +511,6 @@ namespace Ucommerce.Transactions.Payments.Adyen
 		protected void ProcessPaymentNotificationMessage(Payment payment, Dictionary<string, string> dict)
 		{
 			var data = RetrieveNotificationMessageData(dict);
-			payment.TransactionId = data.PspReference;
 			payment[LatestPspReference] = data.PspReference;
 
             Guard.Against.MessageNotAuthenticated(ResultValidator.NotificationMessageIsAuthenticated(payment.PaymentMethod));

--- a/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
@@ -400,6 +400,7 @@ namespace Ucommerce.Transactions.Payments.Adyen
 			var data = RetrieveAuthenticationResultMessageData(dict);
 			payment.TransactionId = data.PspReference;
 			payment[LatestPspReference] = data.PspReference;
+			payment.Save();
 
 			var authenticatedOrPending = false;
 			switch (data.AuthorizationResult)
@@ -412,7 +413,7 @@ namespace Ucommerce.Transactions.Payments.Adyen
 						if (!CheckoutPipelineHasAlreadyBeenExecutedForPayment(payment)) //The checkout pipeline may already have been run at this point.
 						{
 							payment.PurchaseOrder.OrderStatus = OrderStatus.Get((int)OrderStatusCode.Processing); //to remove the link from the basket.
-							payment.PurchaseOrder.Save();	
+							payment.PurchaseOrder.Save();
 						}
 					}
 

--- a/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
@@ -128,7 +128,7 @@ namespace Ucommerce.Transactions.Payments.Adyen
 			{
 				//General notification recieved from Adyen. 
 				LoggingService.Debug<AdyenPaymentMethodService>(
-					string.Format("Notification received, but no payment was found with Reference ID: " + payment["ReferenceId"]));
+					string.Format("Notification received, but no payment was found with Reference ID: " + payment.ReferenceId));
 			}
 			else
 			{

--- a/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
@@ -400,7 +400,6 @@ namespace Ucommerce.Transactions.Payments.Adyen
 			var data = RetrieveAuthenticationResultMessageData(dict);
 			payment.TransactionId = data.PspReference;
 			payment[LatestPspReference] = data.PspReference;
-			payment.Save();
 
 			var authenticatedOrPending = false;
 			switch (data.AuthorizationResult)


### PR DESCRIPTION
When webhook notification is received the `TransactionId` property on a payment isn't set although the `pspReference` is included from Adyen.

Fixes https://github.com/Ucommercenet/UCommerce.Transactions.Payments/issues/35

![image](https://user-images.githubusercontent.com/2919859/170222166-9601c16f-6ce2-4fb4-be4c-50cf8ed3f27f.png)

The **ProcessAuthorizarionResponse** is adding this to audit:
https://github.com/Ucommercenet/UCommerce.Transactions.Payments/blob/develop/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs#L407

and the 

The **ProcessNotificationMessage** is adding this to audit:
https://github.com/Ucommercenet/UCommerce.Transactions.Payments/blob/develop/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs#L524

It seems the Audit from webhook notification was added first (although same timestamp), so maybe there's a theoretically the webhook notification changed payment status first https://github.com/Ucommercenet/UCommerce.Transactions.Payments/blob/develop/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs#L524

and thus it won't go into this:
https://github.com/Ucommercenet/UCommerce.Transactions.Payments/blob/develop/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs#L411-L415