### PR TITLE
chore: Update Braintree SDK to latest

### DIFF
--- a/src/UCommerce.Transactions.Payments.Braintree/UCommerce.Transactions.Payments.Braintree.csproj
+++ b/src/UCommerce.Transactions.Payments.Braintree/UCommerce.Transactions.Payments.Braintree.csproj
@@ -30,13 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Braintree, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31b586f34d3e96c7">
-      <HintPath>..\packages\Braintree.5.2.0\lib\net452\Braintree.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Braintree, Version=5.15.0.0, Culture=neutral, PublicKeyToken=31b586f34d3e96c7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Braintree.5.15.0\lib\net452\Braintree.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/UCommerce.Transactions.Payments.Braintree/packages.config
+++ b/src/UCommerce.Transactions.Payments.Braintree/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Braintree" version="5.2.0" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net47" />
+  <package id="Braintree" version="5.15.0" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net47" />
   <package id="uCommerce.Core" version="9.5.1.21265" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
Braintree has deprecated all older versions than v5.14.0.

<img width="1375" alt="image" src="https://user-images.githubusercontent.com/85161254/212297366-449f3457-a6c9-4590-a7ef-51c5c0d33835.png">
