### PR TITLE
Adyen report crashes webhook fix

### DIFF
--- a/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.Adyen/AdyenPaymentMethodService.cs
@@ -266,8 +266,9 @@ namespace Ucommerce.Transactions.Payments.Adyen
         
         protected virtual void SendAcceptHttpResponse()
         {
-            HttpContext.Current.Response.Write("[accepted]");
-            HttpContext.Current.Response.End();
+            HttpContext.Current?.Response.Write("[accepted]");
+            HttpContext.Current?.Response.End();
         }
+
     }
 }

--- a/src/UCommerce.Transactions.Payments.Braintree/BraintreePaymentMethodService.cs
+++ b/src/UCommerce.Transactions.Payments.Braintree/BraintreePaymentMethodService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Threading;
@@ -43,7 +44,7 @@ namespace Ucommerce.Transactions.Payments.Braintree
 		    BraintreePageBuilder = braintreePageBuilder;
 	    }
 
-	    /// <summary>
+        /// <summary>
         /// Renders the page with the information needed by the payment provider.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Reported by Damask:
Alpha Solutions is experiencing an issue where their webhook no longer functions upon catching a request with the "REPORT_AVAILABLE" event code.

Our findings:
This happens due to the 'report' request type from Adyen not having a payment reference id. Our Payment framework is unable to generate a Payment object without this id. It is then later unable to resolve a null object as a Payment. This causes Ucommerce to respond with a http 500 status, which causes Adyen to refuse further communication on the webhook.

Our actions:
Added handling for reports, which should prevent them from causing this issue again in the future.
Added accept response to Adyen in accordance to their requested format.
Removed a variable in AdyenPaymentProvider, as it introduced a state to the class.