### PR TITLE
chore: Adyen DeployToLocal required .DLL file + Update targeted version (.NET 7.0, NUKE 6.3.0)

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -32,6 +32,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -99,6 +99,12 @@ partial class Build : NukeBuild
                     CopyFileToDirectory(
                         project.GetOutputDir(configuration) / "paypal_base.dll", outputDirectory / "bin");
                 }},
+                {"Adyen", (outputDirectory, configuration) =>
+                {
+                    var project = Solution.GetProject("Ucommerce.Transactions.Payments.Adyen");
+                    CopyFileToDirectory(
+                        project.GetOutputDir(configuration) / "Adyen.dll", outputDirectory / "bin");
+                }},
                 {"Braintree", (outputDirectory, configuration) =>
                 {
                     var project = Solution.GetProject("Ucommerce.Transactions.Payments.Braintree");

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+    <PackageReference Include="Nuke.Common" Version="6.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Problem:
After implementing the new Adyen provider via the provided SDK, an additional dependency is required to be copied into the Apps folder.

Solution:
Added the necessary code in the DeployToLocal method, for the dependency to be added to the .bin folder when deploying locally.

Also updated targeted versions of .NET and NUKE