### PR TITLE
chore(devops): Build project on push

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -1,0 +1,29 @@
+name: Compile
+
+on: [push]
+
+jobs:
+  Build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            7.x
+        
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cache ~/.nuget/packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+
+      - name: Build Solution
+        run: ./build.ps1 compile --Configuration Release


### PR DESCRIPTION
Normally UCommerce.Transactions.Payments build together with the core of Ucommerce. But it is very difficult to see if it fails on a build before the core module builds it. This will build on every push and will require a merge to be built before it ends in develop branch.